### PR TITLE
adds text title

### DIFF
--- a/src/html/templates/textTitle.ejs
+++ b/src/html/templates/textTitle.ejs
@@ -1,0 +1,6 @@
+<section class="text-title">
+    <div class='title'>
+      <h2><%= gt.gettext('Headline goes here')%></h2>
+      <p><%= gt.gettext('Subhed placeholder text here. Subhed placeholder text here.')%></p>
+    </div>
+</section>


### PR DESCRIPTION
hey @hobbes7878 ... just adding basics for a text title alternative. Was wondering if it makes sense to change file name convention from heroTitle and textTitle to titleHero and titleText. 

Related, I can't seem to access  @reuters-graphics/style-theme-eisbaer to add related scss file